### PR TITLE
Stab at initial schema, add SLF4J dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,8 @@
                  [metosin/compojure-api "0.22.1"]
                  [metosin/ring-swagger-ui "2.1.1"]
                  [aleph "0.4.0"]
-                 [http-kit "2.1.19"]]
+                 [http-kit "2.1.19"]
+                 [org.slf4j/slf4j-log4j12 "1.6.6"]]
 
   :min-lein-version "2.0.0"
   :uberjar-name "shoutr.jar"

--- a/resources/migrations/20150818204726-add-users-table.down.sql
+++ b/resources/migrations/20150818204726-add-users-table.down.sql
@@ -1,1 +1,0 @@
-DROP TABLE users;

--- a/resources/migrations/20150818204726-add-users-table.up.sql
+++ b/resources/migrations/20150818204726-add-users-table.up.sql
@@ -1,9 +1,0 @@
-CREATE TABLE users
-(id VARCHAR(20) PRIMARY KEY,
- first_name VARCHAR(30),
- last_name VARCHAR(30),
- email VARCHAR(30),
- admin BOOLEAN,
- last_login TIME,
- is_active BOOLEAN,
- pass VARCHAR(100));

--- a/resources/migrations/20150818224319-add-users-service-service-users-tables.down.sql
+++ b/resources/migrations/20150818224319-add-users-service-service-users-tables.down.sql
@@ -1,0 +1,16 @@
+-- foreign keys
+ALTER TABLE service_users DROP CONSTRAINT service_users__services;
+--;;
+ALTER TABLE service_users DROP CONSTRAINT service_users__users;
+--;;
+
+-- tables
+DROP TABLE services;
+--;;
+
+DROP TABLE service_users;
+--;;
+
+DROP TABLE users;
+--;;
+-- End of file.

--- a/resources/migrations/20150818224319-add-users-service-service-users-tables.up.sql
+++ b/resources/migrations/20150818224319-add-users-service-service-users-tables.up.sql
@@ -1,0 +1,53 @@
+-- tables
+-- Table: service
+CREATE TABLE services (
+    service_uid UUID NOT NULL,
+    service_type int  NOT NULL, --don't know if this should be an int, was thinking this would have a mapping to some kind of enum in the code
+    CONSTRAINT service_pk PRIMARY KEY (service_uid)
+);
+--;;
+
+-- Table: service_users
+CREATE TABLE service_users (
+    service_user_uid UUID NOT NULL, --could also use (user_uid, service_uid) as PK
+    user_uid UUID NOT NULL,
+    service_uid UUID NOT NULL,
+    api_key text  NOT NULL,
+    CONSTRAINT service_users_uniq_user_uid_service_uid UNIQUE (user_uid, service_uid) NOT DEFERRABLE  INITIALLY IMMEDIATE ,
+    CONSTRAINT service_users_pk PRIMARY KEY (service_user_uid)
+);
+--;;
+
+-- Table: users
+CREATE TABLE users (
+    user_uid UUID NOT NULL,
+    username varchar(20)  NOT NULL,
+    password varchar(64)  NOT NULL,
+    email varchar(100) NOT NULL,
+    CONSTRAINT users_pk PRIMARY KEY (user_uid)
+);
+--;;
+
+-- foreign keys
+-- Reference:  service_users__services (table: service_users)
+ALTER TABLE service_users ADD CONSTRAINT service_users__services
+    FOREIGN KEY (service_uid)
+    REFERENCES services (service_uid)
+    ON DELETE  CASCADE
+    ON UPDATE  CASCADE
+    NOT DEFERRABLE
+    INITIALLY IMMEDIATE
+;
+--;;
+
+-- Reference:  service_users__users (table: service_users)
+ALTER TABLE service_users ADD CONSTRAINT service_users__users
+    FOREIGN KEY (user_uid)
+    REFERENCES users (user_uid)
+    ON DELETE  CASCADE
+    ON UPDATE  CASCADE
+    NOT DEFERRABLE
+    INITIALLY IMMEDIATE
+;
+--;;
+-- End of file.


### PR DESCRIPTION
Created an initial schema. 

```
shoutr_dev=# \d
              List of relations
 Schema |       Name        | Type  | Owner
--------+-------------------+-------+--------
 public | schema_migrations | table | shoutr
 public | service_users     | table | shoutr
 public | services          | table | shoutr
 public | users             | table | shoutr
(4 rows)

shoutr_dev=# select * from users; select * from services; select * from service_users ;
 user_uid | username | password | email
----------+----------+----------+-------
(0 rows)

 service_uid | service_type
-------------+--------------
(0 rows)

 service_user_uid | user_uid | service_uid | api_key
------------------+----------+-------------+---------
(0 rows)

shoutr_dev=#
```

![schema](https://cloud.githubusercontent.com/assets/5800836/9348651/c9509cfe-45ff-11e5-8c8f-b89a52b09a00.png)

I also explicitly added SLF4J as a dependency as suggested [here](http://www.slf4j.org/codes.html#StaticLoggerBinder)

We still need to give it an initial config.xml file as noted [here](http://logging.apache.org/log4j/1.2/faq.html#noconfig)
